### PR TITLE
feat: persist active project detail across app restarts

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,9 +8,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import { queryClient } from "./queryClient";
+import { getActiveProjectId } from "./stores/settings";
 import { routeTree } from "./routeTree.gen";
 
-const history = createMemoryHistory();
+const activeProjectId = getActiveProjectId();
+const initialPath = activeProjectId ? `/projects/${activeProjectId}` : "/";
+const history = createMemoryHistory({ initialEntries: [initialPath] });
 // Create a new router instance
 const router = createRouter({ routeTree, history });
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,10 @@
 import { ProjectList } from "@/features/project-list";
+import { setActiveProjectId } from "@/stores/settings";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
   component: ProjectList,
+  beforeLoad: () => {
+    setActiveProjectId(null);
+  },
 });

--- a/src/routes/projects/$id.tsx
+++ b/src/routes/projects/$id.tsx
@@ -1,11 +1,13 @@
 import { ProjectDetail } from "@/features/project-detail";
 import { addOpenedId } from "@/stores/opened-projects";
+import { setActiveProjectId } from "@/stores/settings";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/projects/$id")({
   component: RouteComponent,
   beforeLoad: (ctx) => {
     addOpenedId(ctx.params.id);
+    setActiveProjectId(ctx.params.id);
   },
 });
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -9,12 +9,15 @@ const useSettings = create(
       {
         projectListType: "grid" as ProjectListType,
         searchQuery: "",
+        activeProjectId: null as string | null,
       },
       (set) => ({
         setProjectListType: (type: ProjectListType) =>
           set({ projectListType: type }),
         setSearchQuery: (query: string) =>
           set({ searchQuery: query }),
+        setActiveProjectId: (id: string | null) =>
+          set({ activeProjectId: id }),
       })
     ),
     {
@@ -42,4 +45,12 @@ export function useSearchQuery() {
 
 export function setSearchQuery(query: string) {
   useSettings.getState().setSearchQuery(query);
+}
+
+export function getActiveProjectId(): string | null {
+  return useSettings.getState().activeProjectId;
+}
+
+export function setActiveProjectId(id: string | null) {
+  useSettings.getState().setActiveProjectId(id);
 }


### PR DESCRIPTION
This pull request introduces a new mechanism for tracking the currently active project throughout the application by adding an `activeProjectId` to the settings store. The routing logic is updated to leverage this state, ensuring that navigation and state management remain consistent when users switch between projects or return to the project list.

State management enhancements:

* Added `activeProjectId` to the settings store, along with corresponding getter and setter functions (`getActiveProjectId` and `setActiveProjectId`), allowing the application to keep track of the currently active project in a centralized way. [[1]](diffhunk://#diff-d8d523dfd1e392340443844d193c47b2f06bde1a204fd31f1316ff9d6a53d3f7R12-R20) [[2]](diffhunk://#diff-d8d523dfd1e392340443844d193c47b2f06bde1a204fd31f1316ff9d6a53d3f7R49-R56)

Routing and navigation improvements:

* Updated the main entry point (`src/main.tsx`) to initialize the router's starting path based on the current `activeProjectId`, so users are routed directly to the active project if one is set.
* Modified the root route (`/`) to clear the `activeProjectId` when navigating to the project list, ensuring the state is reset appropriately.
* Updated the project detail route (`/projects/$id`) to set the `activeProjectId` whenever a project is opened, keeping the state in sync with navigation.