### PR TITLE
feat(docs): rewrite and align README in English and Chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,116 @@
 # Video Manager
 
-Manage resources for video processing and storage.
+简体中文: [README.zh-CN.md](README.zh-CN.md)
 
-## Tasks
+Desktop app for organizing video-related resources by project.
 
-### 12.15
+Built with Electron + Vite + React, with IndexedDB for local persistence.
 
-- [x] add react-query for data CRUD
-  - [x] add package dependencies
-  - [x] `projects`
-  - [x] `resources`
-- [x] drag to add resource to project
-- [x] resource list -> grid
-- [x] opened projects
+## Features
 
-### 12.16
+- Project management
+  - Create, update, and delete projects
+  - Auto-open project tabs when navigating to project detail pages
+  - Restore last active project route on app startup
+- Resource management
+  - Add resources by file picker dialog or drag and drop
+  - Manage resources per project
+  - Delete resources, with optional native file deletion
+  - Mark resource status as `used` or `unused`
+  - Edit resource tags and filter by tags/status
+  - Multi-select resources and drag selected files out of the app
+- Project list UX
+  - Grid/list view toggle
+  - Search projects by title, description, and tags
+  - Create a project directly from dropped files
+- Desktop integrations (IPC)
+  - Open native file picker
+  - Reveal file location in Finder
+  - Delete native files from disk
+  - Native drag-out support via `webContents.startDrag`
 
-- [x] Use file input to add resources
-- [x] App name
-- [x] SQLite -> IndexedDB
-- [x] Release 0.1.0
+## Tech Stack
+
+- Electron 30
+- Vite 5
+- React 18 + TypeScript 5
+- TanStack Router (file-based routes)
+- TanStack React Query + react-query-kit
+- Zustand (persisted UI state)
+- IndexedDB (`idb`)
+- Tailwind CSS 4 + Radix UI primitives
+
+## Project Structure
+
+```text
+electron/
+  main.ts        # Electron main process + IPC handlers
+  preload.ts     # Context bridge for renderer
+src/
+  routes/        # File-based routing
+  features/
+    project-list/
+    project-detail/
+  services/      # Query/mutation service layers
+  lib/db.ts      # IndexedDB data access
+  stores/        # Persisted UI/session state
+```
+
+## Data Model
+
+- `ProjectEntity`
+  - `id`, `createdAt`, `updatedAt`
+  - `title`, `description`, `resourcesCount`, `tags`
+- `MaterialEntity`
+  - `id`, `createdAt`, `updatedAt`
+  - `projectId`, `name`, `path`, `size`, `alias`, `status`, `tags`
+
+Notes:
+- Data is stored in IndexedDB database `video-manager-db`.
+- Current DB schema version is `3`.
+- Migration in v3 backfills missing material `status` with `unused`.
+
+## Development
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Start app in development mode:
+
+```bash
+pnpm dev
+```
+
+Build app:
+
+```bash
+pnpm build
+```
+
+Lint:
+
+```bash
+pnpm lint
+```
+
+Preview renderer build:
+
+```bash
+pnpm preview
+```
+
+## Routing
+
+- `/` project list
+- `/projects/` project list
+- `/projects/$id` project detail
+
+Root layout includes top tabs for opened projects and per-route content rendering.
+
+## Notes
+
+- App state such as opened project tabs and list/search preferences is persisted with Zustand.
+- Query invalidation is tag-based via custom React Query metadata in `src/queryClient.ts`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,114 @@
+# Video Manager（中文）
+
+用于按项目管理视频相关资源的桌面应用。
+
+基于 Electron + Vite + React，数据本地存储在 IndexedDB。
+
+## 主要功能
+
+- 项目管理
+  - 创建、更新、删除项目
+  - 进入项目详情时自动打开对应项目标签页
+  - 应用启动时恢复上次激活的项目路由
+- 资源管理
+  - 通过文件选择器或拖拽添加资源
+  - 按项目管理资源
+  - 删除资源，并可选删除本地原文件
+  - 将资源状态标记为 `used` 或 `unused`
+  - 编辑资源标签，并按标签/状态筛选
+  - 多选资源并将选中资源拖拽导出到应用外
+- 项目列表体验
+  - 网格/列表视图切换
+  - 按标题、描述、标签搜索项目
+  - 直接通过拖拽文件创建新项目
+- 桌面集成（IPC）
+  - 打开系统文件选择器
+  - 在 Finder 中定位文件
+  - 从磁盘删除本地文件
+  - 通过 `webContents.startDrag` 支持原生拖拽导出
+
+## 技术栈
+
+- Electron 30
+- Vite 5
+- React 18 + TypeScript 5
+- TanStack Router + React Query
+- Zustand
+- IndexedDB（idb）
+- Tailwind CSS 4 + Radix UI
+
+## 项目结构
+
+```text
+electron/
+	main.ts        # Electron 主进程与 IPC 处理
+	preload.ts     # 渲染进程上下文桥接
+src/
+	routes/        # 文件路由
+	features/
+		project-list/
+		project-detail/
+	services/      # 查询与变更服务层
+	lib/db.ts      # IndexedDB 数据访问
+	stores/        # 持久化 UI/会话状态
+```
+
+## 数据模型
+
+- ProjectEntity
+  - id, createdAt, updatedAt
+  - title, description, resourcesCount, tags
+- MaterialEntity
+  - id, createdAt, updatedAt
+  - projectId, name, path, size, alias, status, tags
+
+说明：
+
+- 数据存储在 IndexedDB，数据库名为 video-manager-db。
+- 当前数据库 schema 版本为 3。
+- v3 迁移会为缺失 status 的资源回填 unused。
+
+## 开发
+
+安装依赖：
+
+```bash
+pnpm install
+```
+
+启动开发模式：
+
+```bash
+pnpm dev
+```
+
+构建应用：
+
+```bash
+pnpm build
+```
+
+代码检查：
+
+```bash
+pnpm lint
+```
+
+预览渲染端构建产物：
+
+```bash
+pnpm preview
+```
+
+## 路由
+
+- /：项目列表
+- /projects/：项目列表
+- /projects/$id：项目详情
+
+根布局包含已打开项目的顶部标签栏，并按路由渲染页面内容。
+
+## 备注
+
+- 已打开项目标签、列表视图偏好、搜索关键字等应用状态通过 Zustand 持久化。
+- 查询失效策略基于 React Query 自定义元数据中的标签机制（见 src/queryClient.ts）。


### PR DESCRIPTION
- Overhauled README.md: replaced old task log with full project documentation, including features, tech stack, project structure, data model, development commands, routing, and notes.
- Added 简体中文入口链接，新增并完善了 README.zh-CN.md，使其与英文版内容结构一一对应，包括主要功能、技术栈、项目结构、数据模型、开发、路由和备注等章节。