### PR TITLE
Implement recycle bin with soft-delete and management features

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Plus, Video, X } from "lucide-react";
+import { Plus, Trash2, Video, X } from "lucide-react";
 import * as React from "react";
 
 import {
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/sidebar";
 import { useAddProject } from "@/features/project-list/hooks/useAddProject";
 import { projects } from "@/services/projects";
+import { resources } from "@/services/resources";
 import { deleteOpenedId, useOpenedIds } from "@/stores/opened-projects";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { Button } from "./ui/button";
@@ -72,6 +73,9 @@ function OpenedProjects() {
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const [addProject] = useAddProject();
+  const { data: trashMaterials } = resources.trashList.useQuery();
+  const trashCount = trashMaterials?.length ?? 0;
+
   return (
     <Sidebar variant="floating" {...props}>
       <SidebarHeader>
@@ -102,6 +106,23 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       <SidebarContent>
         <SidebarGroup>
           <OpenedProjects />
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild>
+                <Link to="/recycle-bin">
+                  <Trash2 className="size-4" />
+                  <span>Recycle Bin</span>
+                  {trashCount > 0 && (
+                    <span className="ms-auto text-xs bg-destructive text-destructive-foreground rounded-full px-1.5 py-0.5 min-w-5 text-center leading-tight">
+                      {trashCount}
+                    </span>
+                  )}
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
         </SidebarGroup>
       </SidebarContent>
     </Sidebar>

--- a/src/features/project-detail/components/DeleteResource.tsx
+++ b/src/features/project-detail/components/DeleteResource.tsx
@@ -12,65 +12,35 @@ import {
 import { resources } from "@/services/resources";
 import { useDisclosure } from "@domeadev/react-disclosure";
 import { Slot, SlotProps } from "@radix-ui/react-slot";
-import { useState } from "react";
 import { toast } from "sonner";
 
 interface Props extends SlotProps {
   resourceId: number;
-  resourcePath: string;
 }
 
 export type DeleteResourceProps = Props;
 
 export function DeleteResource({
   resourceId,
-  resourcePath,
   children,
   ...props
 }: Props) {
   const deleteMutation = resources.delete.useMutation();
-  const { data, refetch } = resources.getMaterialsByPath.useQuery({
-    variables: { path: resourcePath },
-  });
   const [open, toggleOpen] = useDisclosure();
-  const shouldConfirmDeleteNative =
-    data?.length === 1 && data[0].id === resourceId;
-  const [shouldDeleteNative, setShouldDeleteNative] = useState<boolean>(false);
 
   return (
     <Dialog open={open} onOpenChange={toggleOpen}>
-      <DialogTrigger
-        asChild
-        onClick={() => {
-          refetch();
-          setShouldDeleteNative(false);
-        }}
-      >
+      <DialogTrigger asChild>
         <Slot {...props}>{children}</Slot>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete Resource</DialogTitle>
+          <DialogTitle>Move to Recycle Bin</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          Are you sure you want to delete this resource?
+          Are you sure you want to move this resource to the recycle bin?
+          You can restore it later or permanently delete it from there.
         </DialogDescription>
-        {shouldConfirmDeleteNative ? (
-          <div>
-            <label className="inline-flex flex-row items-start space-x-2">
-              <input
-                type="checkbox"
-                className="mt-1"
-                checked={shouldDeleteNative}
-                onChange={(e) => setShouldDeleteNative(e.target.checked)}
-              />
-              <span className="text-xs text-destructive">
-                This file is not used by any other projects. Do you want to
-                delete the native file as well?
-              </span>
-            </label>
-          </div>
-        ) : null}
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
@@ -80,23 +50,20 @@ export function DeleteResource({
             variant="destructive"
             onClick={() => {
               deleteMutation.mutate(
-                {
-                  id: resourceId,
-                  shouldDeleteNative,
-                },
+                { id: resourceId },
                 {
                   onSuccess: () => {
-                    toast.success("Resource deleted");
+                    toast.success("Resource moved to recycle bin");
                     toggleOpen(false);
                   },
                   onError: () => {
-                    toast.error("Failed to delete resource");
+                    toast.error("Failed to move resource to recycle bin");
                   },
                 },
               );
             }}
           >
-            Delete
+            Move to Recycle Bin
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/project-detail/components/ResourceCard.tsx
+++ b/src/features/project-detail/components/ResourceCard.tsx
@@ -140,7 +140,7 @@ export function ResourceCard({
             </Button>
           </EditResourceTags>
 
-          <DeleteResource resourceId={material.id} resourcePath={material.path}>
+          <DeleteResource resourceId={material.id}>
             <Button
               variant="secondary"
               size="icon-sm"

--- a/src/features/recycle-bin/components/EmptyTrashDialog.tsx
+++ b/src/features/recycle-bin/components/EmptyTrashDialog.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+
+interface Props {
+  itemCount: number;
+  onConfirm: (deleteNative: boolean) => void;
+}
+
+export function EmptyTrashDialog({ itemCount, onConfirm }: Props) {
+  const [open, setOpen] = useState(false);
+  const [deleteNative, setDeleteNative] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Trash2 className="size-3.5 mr-1" />
+          Empty Recycle Bin
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Empty Recycle Bin</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>
+          This will permanently delete all {itemCount} item(s) in the recycle
+          bin. This action cannot be undone.
+        </DialogDescription>
+        <div>
+          <label className="inline-flex flex-row items-start space-x-2 cursor-pointer">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={deleteNative}
+              onChange={(e) => setDeleteNative(e.target.checked)}
+            />
+            <span className="text-xs text-destructive">
+              Also delete native files from disk for all items.
+            </span>
+          </label>
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              onConfirm(deleteNative);
+              setOpen(false);
+            }}
+          >
+            Empty Recycle Bin
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/recycle-bin/components/PermanentDeleteDialog.tsx
+++ b/src/features/recycle-bin/components/PermanentDeleteDialog.tsx
@@ -1,0 +1,91 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { resources } from "@/services/resources";
+import { Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface Props {
+  material: { id: number; name: string; path: string };
+  onConfirm: (shouldDeleteNative: boolean) => void;
+}
+
+export function PermanentDeleteDialog({ material, onConfirm }: Props) {
+  const [open, setOpen] = useState(false);
+  const [shouldDeleteNative, setShouldDeleteNative] = useState(false);
+  const { data, refetch } = resources.getMaterialsByPath.useQuery({
+    variables: { path: material.path },
+  });
+
+  useEffect(() => {
+    if (open) {
+      setShouldDeleteNative(false);
+      refetch();
+    }
+  }, [open, refetch]);
+
+  const canDeleteNative = data?.length === 1 && data[0].id === material.id;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="destructive">
+          <Trash2 className="size-3.5 mr-1" />
+          Delete Forever
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Permanently Delete</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>
+          This action cannot be undone. The resource will be permanently removed
+          from the recycle bin.
+        </DialogDescription>
+        <div className="text-sm space-y-1">
+          <p>
+            <strong>File:</strong> {material.name}
+          </p>
+          <p className="text-muted-foreground break-all">{material.path}</p>
+        </div>
+        {canDeleteNative && (
+          <div>
+            <label className="inline-flex flex-row items-start space-x-2 cursor-pointer">
+              <input
+                type="checkbox"
+                className="mt-1"
+                checked={shouldDeleteNative}
+                onChange={(e) => setShouldDeleteNative(e.target.checked)}
+              />
+              <span className="text-xs text-destructive">
+                Also delete the native file from disk. This cannot be undone.
+              </span>
+            </label>
+          </div>
+        )}
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              onConfirm(shouldDeleteNative);
+              setOpen(false);
+            }}
+          >
+            Delete Forever
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/recycle-bin/components/TrashMaterialRow.tsx
+++ b/src/features/recycle-bin/components/TrashMaterialRow.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@/components/ui/button";
+import { formatBytes } from "@/utils/formatBytes";
+import type { MaterialEntity } from "@/typings";
+import { RotateCcw } from "lucide-react";
+import { useProjectName } from "../hooks/useProjectName";
+import { PermanentDeleteDialog } from "./PermanentDeleteDialog";
+
+interface Props {
+  material: MaterialEntity;
+  onRestore: (id: number) => void;
+  onPermanentDelete: (id: number, shouldDeleteNative: boolean) => void;
+}
+
+export function TrashMaterialRow({
+  material,
+  onRestore,
+  onPermanentDelete,
+}: Props) {
+  const projectName = useProjectName(material.projectId);
+
+  return (
+    <div className="flex items-center gap-4 p-3 border border-border rounded-lg bg-card">
+      {/* Thumbnail */}
+      <div className="size-12 shrink-0 rounded-md bg-muted overflow-hidden">
+        <img
+          src={`file://${material.path}`}
+          alt=""
+          className="w-full h-full object-cover"
+          onError={(e) => {
+            (e.target as HTMLImageElement).style.display = "none";
+          }}
+        />
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-sm truncate">{material.name}</div>
+        <div className="text-xs text-muted-foreground">
+          {formatBytes(material.size)} — From: {projectName}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          Deleted:{" "}
+          {material.deletedAt
+            ? new Date(material.deletedAt).toLocaleString()
+            : "Unknown"}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 shrink-0">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onRestore(material.id)}
+        >
+          <RotateCcw className="size-3.5 mr-1" />
+          Restore
+        </Button>
+        <PermanentDeleteDialog
+          material={material}
+          onConfirm={(shouldDeleteNative) => {
+            onPermanentDelete(material.id, shouldDeleteNative);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/recycle-bin/hooks/useProjectName.ts
+++ b/src/features/recycle-bin/hooks/useProjectName.ts
@@ -1,0 +1,8 @@
+import { projects } from "@/services/projects";
+
+export function useProjectName(projectId: number): string {
+  const { data } = projects.list.useQuery();
+  if (!data) return `Project #${projectId}`;
+  const project = data.find((p) => p.id === projectId);
+  return project?.title ?? `Project #${projectId}`;
+}

--- a/src/features/recycle-bin/index.tsx
+++ b/src/features/recycle-bin/index.tsx
@@ -1,0 +1,110 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { resources } from "@/services/resources";
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { EmptyTrashDialog } from "./components/EmptyTrashDialog";
+import { TrashMaterialRow } from "./components/TrashMaterialRow";
+
+export function RecycleBinPage() {
+  const { data: trashMaterials, isLoading } = resources.trashList.useQuery();
+  const restoreMutation = resources.trashRestore.useMutation();
+  const deleteMutation = resources.trashDelete.useMutation();
+  const emptyMutation = resources.trashEmpty.useMutation();
+
+  const handleRestore = (id: number) => {
+    restoreMutation.mutate(
+      { id },
+      {
+        onSuccess: () => toast.success("Resource restored"),
+        onError: () => toast.error("Failed to restore resource"),
+      },
+    );
+  };
+
+  const handlePermanentDelete = (id: number, shouldDeleteNative: boolean) => {
+    deleteMutation.mutate(
+      { id, shouldDeleteNative },
+      {
+        onSuccess: () => toast.success("Resource permanently deleted"),
+        onError: () => toast.error("Failed to delete resource"),
+      },
+    );
+  };
+
+  const handleEmptyTrash = (deleteNative: boolean) => {
+    emptyMutation.mutate(
+      { deleteNative },
+      {
+        onSuccess: () => toast.success("Recycle bin emptied"),
+        onError: () => toast.error("Failed to empty recycle bin"),
+      },
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-semibold">Recycle Bin</h1>
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="size-5" />
+          </Link>
+          <h1 className="text-2xl font-semibold">Recycle Bin</h1>
+        </div>
+        {trashMaterials && trashMaterials.length > 0 && (
+          <EmptyTrashDialog
+            itemCount={trashMaterials.length}
+            onConfirm={handleEmptyTrash}
+          />
+        )}
+      </div>
+
+      {!trashMaterials || trashMaterials.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-24 text-center">
+          <div className="bg-muted rounded-full p-4 mb-4">
+            <Trash2 className="size-8 text-muted-foreground" />
+          </div>
+          <h2 className="text-lg font-semibold text-foreground mb-1">
+            Recycle bin is empty
+          </h2>
+          <p className="text-sm text-muted-foreground max-w-xs">
+            Deleted resources will appear here. You can restore them or
+            permanently delete them.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground mb-4">
+            {trashMaterials.length} item(s) in recycle bin
+          </p>
+          {trashMaterials.map((material) => (
+            <TrashMaterialRow
+              key={material.id}
+              material={material}
+              onRestore={handleRestore}
+              onPermanentDelete={handlePermanentDelete}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,12 +10,12 @@ interface VideoManagerDB extends DBSchema {
   materials: {
     key: number;
     value: MaterialEntity;
-    indexes: { "projectId": number; "updatedAt": number };
+    indexes: { "projectId": number; "updatedAt": number; "deletedAt": number };
   };
 }
 
 const DB_NAME = "video-manager-db";
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 
 let dbPromise: Promise<IDBPDatabase<VideoManagerDB>>;
 
@@ -64,6 +64,13 @@ function getDB() {
             }
           }
         }
+
+        // Migration for version 4: Add deletedAt index for recycle bin
+        if (oldVersion < 4) {
+          if (!materialStore.indexNames.contains("deletedAt")) {
+            materialStore.createIndex("deletedAt", "deletedAt");
+          }
+        }
       },
     });
   }
@@ -77,8 +84,9 @@ export const db = {
     const projectsWithCount = await Promise.all(
       projects.map(async (p) => {
         const materials = await db.getAllFromIndex("materials", "projectId", p.id);
-        const tags = [...new Set(materials.flatMap((m) => m.tags ?? []))];
-        return { ...p, resourcesCount: materials.length, tags };
+        const activeMaterials = materials.filter((m) => !m.deletedAt);
+        const tags = [...new Set(activeMaterials.flatMap((m) => m.tags ?? []))];
+        return { ...p, resourcesCount: activeMaterials.length, tags };
       })
     );
     return projectsWithCount.reverse();
@@ -134,7 +142,9 @@ export const db = {
       "projectId",
       projectId
     );
-    return materials.sort((a, b) => b.updatedAt - a.updatedAt);
+    return materials
+      .filter((m) => !m.deletedAt)
+      .sort((a, b) => b.updatedAt - a.updatedAt);
   },
   getMaterial: async (id: number): Promise<MaterialEntity | undefined> => {
     const db = await getDB();
@@ -168,6 +178,62 @@ export const db = {
     const db = await getDB();
     await db.delete("materials", id);
     return id;
+  },
+  trashMaterial: async (id: number) => {
+    const db = await getDB();
+    const material = await db.get("materials", id);
+    if (!material) throw new Error("Material not found");
+    material.deletedAt = Date.now();
+    material.updatedAt = material.deletedAt;
+    await db.put("materials", material);
+    return id;
+  },
+  restoreMaterial: async (id: number) => {
+    const db = await getDB();
+    const material = await db.get("materials", id);
+    if (!material) throw new Error("Material not found");
+    delete material.deletedAt;
+    material.updatedAt = Date.now();
+    await db.put("materials", material);
+    return id;
+  },
+  getTrashMaterials: async (): Promise<MaterialEntity[]> => {
+    const db = await getDB();
+    const deleted: MaterialEntity[] = [];
+    let cursor = await db
+      .transaction("materials")
+      .store.index("deletedAt")
+      .openCursor(IDBKeyRange.lowerBound(1));
+    while (cursor) {
+      deleted.push(cursor.value);
+      cursor = await cursor.continue();
+    }
+    return deleted.sort(
+      (a, b) => (b.deletedAt ?? 0) - (a.deletedAt ?? 0)
+    );
+  },
+  emptyTrash: async (options?: { deleteNative?: boolean }) => {
+    const database = await getDB();
+    const paths: string[] = [];
+    const tx = database.transaction("materials", "readwrite");
+    let cursor = await tx.store
+      .index("deletedAt")
+      .openCursor(IDBKeyRange.lowerBound(1));
+    while (cursor) {
+      paths.push(cursor.value.path);
+      await cursor.delete();
+      cursor = await cursor.continue();
+    }
+    await tx.done;
+    if (options?.deleteNative) {
+      for (const path of paths) {
+        try {
+          await db.deleteNativeFile(path);
+        } catch {
+          // silently skip individual file deletion errors during bulk empty
+        }
+      }
+    }
   },
   getMaterialsByPath: async (filePath: string): Promise<MaterialEntity[]> => {
     const db = await getDB();

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,10 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as RecycleBinRouteImport } from './routes/recycle-bin'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProjectsIndexRouteImport } from './routes/projects/index'
 import { Route as ProjectsIdRouteImport } from './routes/projects/$id'
 
+const RecycleBinRoute = RecycleBinRouteImport.update({
+  id: '/recycle-bin',
+  path: '/recycle-bin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -31,36 +37,47 @@ const ProjectsIdRoute = ProjectsIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/recycle-bin': typeof RecycleBinRoute
   '/projects/$id': typeof ProjectsIdRoute
   '/projects': typeof ProjectsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/recycle-bin': typeof RecycleBinRoute
   '/projects/$id': typeof ProjectsIdRoute
   '/projects': typeof ProjectsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/recycle-bin': typeof RecycleBinRoute
   '/projects/$id': typeof ProjectsIdRoute
   '/projects/': typeof ProjectsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/projects/$id' | '/projects'
+  fullPaths: '/' | '/recycle-bin' | '/projects/$id' | '/projects'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/projects/$id' | '/projects'
-  id: '__root__' | '/' | '/projects/$id' | '/projects/'
+  to: '/' | '/recycle-bin' | '/projects/$id' | '/projects'
+  id: '__root__' | '/' | '/recycle-bin' | '/projects/$id' | '/projects/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  RecycleBinRoute: typeof RecycleBinRoute
   ProjectsIdRoute: typeof ProjectsIdRoute
   ProjectsIndexRoute: typeof ProjectsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/recycle-bin': {
+      id: '/recycle-bin'
+      path: '/recycle-bin'
+      fullPath: '/recycle-bin'
+      preLoaderRoute: typeof RecycleBinRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  RecycleBinRoute: RecycleBinRoute,
   ProjectsIdRoute: ProjectsIdRoute,
   ProjectsIndexRoute: ProjectsIndexRoute,
 }

--- a/src/routes/recycle-bin.tsx
+++ b/src/routes/recycle-bin.tsx
@@ -1,0 +1,6 @@
+import { RecycleBinPage } from "@/features/recycle-bin";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/recycle-bin")({
+  component: RecycleBinPage,
+});

--- a/src/services/resources.ts
+++ b/src/services/resources.ts
@@ -43,7 +43,29 @@ export const resources = router("resources", {
   }),
   delete: router.mutation({
     meta: {
-      invalidatesTags: ["Resources"],
+      invalidatesTags: ["Resources", "Trash"],
+    },
+    mutationFn: async (variables: { id: number | string }) => {
+      await db.trashMaterial(+variables.id);
+    },
+  }),
+  trashList: router.query({
+    meta: {
+      tags: ["Trash"],
+    },
+    fetcher: () => db.getTrashMaterials(),
+  }),
+  trashRestore: router.mutation({
+    meta: {
+      invalidatesTags: ["Trash", "Resources"],
+    },
+    mutationFn: async (variables: { id: number | string }) => {
+      await db.restoreMaterial(+variables.id);
+    },
+  }),
+  trashDelete: router.mutation({
+    meta: {
+      invalidatesTags: ["Trash"],
     },
     mutationFn: async (variables: {
       id: number | string;
@@ -51,10 +73,19 @@ export const resources = router("resources", {
     }) => {
       const resourceId = +variables.id;
       const resource = await db.getMaterial(resourceId);
+      if (!resource) throw new Error("Material not found");
       await db.deleteMaterial(resourceId);
       if (variables.shouldDeleteNative) {
-        await db.deleteNativeFile(resource!.path);
+        await db.deleteNativeFile(resource.path);
       }
+    },
+  }),
+  trashEmpty: router.mutation({
+    meta: {
+      invalidatesTags: ["Trash", "Resources"],
+    },
+    mutationFn: async (variables?: { deleteNative?: boolean }) => {
+      await db.emptyTrash(variables);
     },
   }),
   updateStatus: router.mutation({

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -19,4 +19,5 @@ export interface MaterialEntity extends BaseEntity {
   path: string;
   status: 'used' | 'unused';
   tags?: string[];
+  deletedAt?: number;
 }


### PR DESCRIPTION
This pull request introduces a comprehensive "Recycle Bin" (soft-delete) feature for resource management, allowing users to move resources to a recycle bin, restore them, or permanently delete them (with optional native file deletion). The changes span UI updates, IndexedDB schema and migration, and new/updated components and hooks to support the full recycle bin workflow.

**Key changes include:**

### Recycle Bin Feature Implementation

* Added a new `Recycle Bin` page (`src/features/recycle-bin/index.tsx`) that lists deleted resources, allows restoring or permanently deleting individual items, and supports emptying the entire bin with optional native file deletion.
* Introduced supporting UI components: `EmptyTrashDialog`, `PermanentDeleteDialog`, and `TrashMaterialRow` for item actions and confirmation dialogs. [[1]](diffhunk://#diff-7bb10733cb0eb389065b2d3a45bb2f8ba813c4d14176ee9f80afefb2fdad8c87R1-R70) [[2]](diffhunk://#diff-342ba82d9157ff5b2ebfe5b0909748fbc13ff9fe4ee82a83b602ac702a602c55R1-R91) [[3]](diffhunk://#diff-015489bef83178c1f9720c7bcbd788efaa03b5fd11cb659052c512998a74e2dbR1-R68)
* Added the `useProjectName` hook to resolve project names for deleted resources.

### Database and Backend Changes

* Updated the IndexedDB schema to version 4, adding a `deletedAt` index for soft-deleted resources, and implemented migration logic. [[1]](diffhunk://#diff-196dc6cfdb581213173439841d9e85ada909cf40face80a3ac1b6739bbd85bf6L13-R18) [[2]](diffhunk://#diff-196dc6cfdb581213173439841d9e85ada909cf40face80a3ac1b6739bbd85bf6R67-R73)
* Added new database methods: `trashMaterial`, `restoreMaterial`, `getTrashMaterials`, and `emptyTrash` to support recycle bin operations, and updated existing queries to exclude trashed resources. [[1]](diffhunk://#diff-196dc6cfdb581213173439841d9e85ada909cf40face80a3ac1b6739bbd85bf6L80-R89) [[2]](diffhunk://#diff-196dc6cfdb581213173439841d9e85ada909cf40face80a3ac1b6739bbd85bf6L137-R147) [[3]](diffhunk://#diff-196dc6cfdb581213173439841d9e85ada909cf40face80a3ac1b6739bbd85bf6R182-R237)

### UI and Workflow Integration

* Updated the app sidebar (`src/components/app-sidebar.tsx`) to display a "Recycle Bin" menu item with a dynamic badge showing the count of deleted resources. [[1]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6L1-R1) [[2]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R15) [[3]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R76-R78) [[4]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R110-R126)
* Refactored the `DeleteResource` component to move resources to the recycle bin instead of deleting them immediately, and updated related UI/UX text. [[1]](diffhunk://#diff-3f2cec901a60108a370390f33de32ba217cae78d03cb3ec9ca917d1f3e0525f3L15-L73) [[2]](diffhunk://#diff-3f2cec901a60108a370390f33de32ba217cae78d03cb3ec9ca917d1f3e0525f3L83-R66) [[3]](diffhunk://#diff-cf2ea68e8512787f40460dd44f859837b56a2dd4db95ca6902387df5c0737159L143-R143)

These changes collectively provide a safer and more user-friendly resource deletion workflow, with clear options for recovery and permanent removal.